### PR TITLE
fixed flake8 issues

### DIFF
--- a/sauron/exporters.py
+++ b/sauron/exporters.py
@@ -111,7 +111,7 @@ class RuleEngineExporter(DefaultExporter):
         result = super().export_job(jobs)
         # Separar jobs por tipo
         result_splited_by_type = {}
-        for key,value in result.items():
+        for key, value in result.items():
             current_type = result_splited_by_type.get(value["type"], {})
             current_type[key] = value
             result_splited_by_type[value["type"]] = current_type

--- a/sauron/parsers.py
+++ b/sauron/parsers.py
@@ -56,8 +56,10 @@ class DefaultParser:
 
 class RuleEngineParser(DefaultParser):
     single_model: Type[JobModel] = JobModel
+
     def __init__(self):
         self.yaml = YAML(typ="safe")
+
     def _parse_jobs_from_string(self, jobs_input: str) -> List[JobModel]:
         """
         Method that know how to parse a list for jobs described by a

--- a/sauron/rule_engine.py
+++ b/sauron/rule_engine.py
@@ -3,11 +3,12 @@ from typing import Callable, Type
 from .parsers import DefaultParser, RuleEngineParser
 from .exporters import DefaultExporter, RuleEngineExporter
 
+
 class RuleEngine(Engine):
 
     parser_class: Type[DefaultParser] = RuleEngineParser
     exporter_class: Type[DefaultExporter] = RuleEngineExporter
-    
+
     def condition(self, *args, **kwargs):
         """
         Decorator so jobs can be called as follows:
@@ -24,7 +25,7 @@ class RuleEngine(Engine):
             return function
 
         return decorator
-    
+
     def action(self, *args, **kwargs):
         """
         Decorator so jobs can be called as follows:

--- a/tests/engine_tests/parsers/test_default_parser.py
+++ b/tests/engine_tests/parsers/test_default_parser.py
@@ -41,7 +41,7 @@ class TestCaseOne:
         assert result[1].job_type == "action"
 
     def setup_yaml(self):
-        with open("tests/utils/first_rule.yaml","r") as f:
+        with open("tests/utils/first_rule.yaml", "r") as f:
             test_string = f.read().strip()
         p = DefaultParser()
         result = p.parse(test_string)

--- a/tests/rule_engine_tests/test_simple_rule_engine.py
+++ b/tests/rule_engine_tests/test_simple_rule_engine.py
@@ -34,12 +34,13 @@ def test_can_subclass_and_instantiate_rule_engine():
     parents = inspect.getmro(instance.__class__)
     assert parents[1] == RuleEngine
 
+
 def test_can_run_rules(json_rule_can_increment):
     engine = RuleEngine()
     number_to_be_incremented = 1
 
     @engine.condition()
-    def is_smaller_than(session,compared_to: int) -> bool:
+    def is_smaller_than(session, compared_to: int) -> bool:
         return number_to_be_incremented < compared_to
 
     @engine.action()
@@ -56,7 +57,7 @@ def test_can_run_rules_and_will_respect_them(json_rule_can_increment):
     number_to_be_incremented = 1
 
     @engine.condition()
-    def is_smaller_than(session,compared_to: int) -> bool:
+    def is_smaller_than(session, compared_to: int) -> bool:
         return number_to_be_incremented < compared_to
 
     @engine.action()


### PR DESCRIPTION
```
./tests/engine_tests/parsers/test_default_parser.py:44:48: E231 missing whitespace after ','
./tests/rule_engine_tests/test_simple_rule_engine.py:37:1: E302 expected 2 blank lines, found 1
./tests/rule_engine_tests/test_simple_rule_engine.py:42:32: E231 missing whitespace after ','
./tests/rule_engine_tests/test_simple_rule_engine.py:59:32: E231 missing whitespace after ','
./sauron/parsers.py:59:5: E301 expected 1 blank line, found 0
./sauron/parsers.py:61:5: E301 expected 1 blank line, found 0
./sauron/rule_engine.py:6:1: E302 expected 2 blank lines, found 1
./sauron/rule_engine.py:10:1: W293 blank line contains whitespace
./sauron/rule_engine.py:27:1: W293 blank line contains whitespace
```