### PR TITLE
Batch jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,8 +226,11 @@ Results in the following json to be served to your frontend:
 
 ## Sessions
 
-Results are stored in a result stack inside the session, so that jobs can share data with each other. 
+Results are stored in a result stack inside the session, so that jobs can share data with each other.
 
+## Job Modules
+
+It is possible to write generic/reusable job files to avoid duplication and streamline development.
 
 ## More Features coming to town
 

--- a/sauron/engine.py
+++ b/sauron/engine.py
@@ -68,11 +68,24 @@ class Engine:
         return decorator
 
     def import_jobs(self, JobModule: ModuleType):
-        raw_job_list: List[Tuple[str, Callable]] = inspect.getmembers(
-            JobModule, predicate=inspect.isfunction
-        )
+        try:
+            raw_job_list: List[
+                Tuple[str, Dict[str, Any]]
+            ] = JobModule.jobs_list
+        except AttributeError:
+            pre_raw_job_list: List[Tuple[str, Callable]] = inspect.getmembers(
+                JobModule, predicate=inspect.isfunction
+            )
+            raw_job_list: List[Tuple[str, Dict[str, Any]]] = [
+                (job[0], {"callable": job[1], "verbose_name": job[0]})
+                for job in pre_raw_job_list
+            ]
         for job in raw_job_list:
-            self._add_callable(job[1], verbose_name=job[0])
+            self._add_callable(
+                job[1].get("callable"),
+                verbose_name=job[1].get("verbose_name", job[0]),
+                job_type=job[1].get("type", "job"),
+            )
 
     def apply_job_call(
         self, job: JobModel, session: Dict[str, Any]

--- a/sauron/engine.py
+++ b/sauron/engine.py
@@ -67,19 +67,28 @@ class Engine:
 
         return decorator
 
-    def import_jobs(self, JobModule: ModuleType):
-        try:
-            raw_job_list: List[
-                Tuple[str, Dict[str, Any]]
-            ] = JobModule.jobs_list
-        except AttributeError:
-            pre_raw_job_list: List[Tuple[str, Callable]] = inspect.getmembers(
-                JobModule, predicate=inspect.isfunction
-            )
-            raw_job_list: List[Tuple[str, Dict[str, Any]]] = [
-                (job[0], {"callable": job[1], "verbose_name": job[0]})
-                for job in pre_raw_job_list
-            ]
+    def import_jobs(
+        self,
+        job_module: ModuleType,
+        job_metadata: List[Tuple[str, Dict[str, Any]]] = None,
+    ):
+        if job_metadata is not None:
+            raw_job_list: job_metadata
+        else:
+            try:
+                raw_job_list: List[
+                    Tuple[str, Dict[str, Any]]
+                ] = job_module.jobs_list
+            except AttributeError:
+                pre_raw_job_list: List[
+                    Tuple[str, Callable]
+                ] = inspect.getmembers(
+                    job_module, predicate=inspect.isfunction
+                )
+                raw_job_list: List[Tuple[str, Dict[str, Any]]] = [
+                    (job[0], {"callable": job[1], "verbose_name": job[0]})
+                    for job in pre_raw_job_list
+                ]
         for job in raw_job_list:
             self._add_callable(
                 job[1].get("callable"),

--- a/sauron/engine.py
+++ b/sauron/engine.py
@@ -3,6 +3,7 @@ from typing import List, Dict, Callable, Union, Any, Type, Tuple
 from .models import JobModel
 from .parsers import DefaultParser
 from .exporters import DefaultExporter
+import inspect
 
 
 class Engine:
@@ -39,11 +40,13 @@ class Engine:
             self.exporter_class = exporter_class
         self.callables_collected: "OrderedDict[str, Dict[str, Any]]" = OrderedDict()
 
-    def _add_callable(self, function: Callable, verbose_name: str, job_type: str = "job"):
+    def _add_callable(
+        self, function: Callable, verbose_name: str, job_type: str = "job"
+    ):
         self.callables_collected[function.__name__] = {
             "function": function,
             "verbose_name": verbose_name,
-            "type": job_type
+            "type": job_type,
         }
 
     def job(self, *args, **kwargs):
@@ -62,6 +65,12 @@ class Engine:
             return function
 
         return decorator
+
+    def import_jobs(self, JobClass: object):
+        raw_job_list: List[Tuple[str, Callable]] = inspect.getmembers(
+            JobClass, predicate=inspect.isfunction
+        )
+        print(raw_job_list)
 
     def apply_job_call(
         self, job: JobModel, session: Dict[str, Any]

--- a/sauron/engine.py
+++ b/sauron/engine.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from types import ModuleType
 from typing import List, Dict, Callable, Union, Any, Type, Tuple
 from .models import JobModel
 from .parsers import DefaultParser
@@ -66,11 +67,12 @@ class Engine:
 
         return decorator
 
-    def import_jobs(self, JobClass: object):
+    def import_jobs(self, JobModule: ModuleType):
         raw_job_list: List[Tuple[str, Callable]] = inspect.getmembers(
-            JobClass, predicate=inspect.isfunction
+            JobModule, predicate=inspect.isfunction
         )
-        print(raw_job_list)
+        for job in raw_job_list:
+            self._add_callable(job[1], verbose_name=job[0])
 
     def apply_job_call(
         self, job: JobModel, session: Dict[str, Any]

--- a/tests/engine_tests/test_import_jobs.py
+++ b/tests/engine_tests/test_import_jobs.py
@@ -2,7 +2,7 @@ from typing import List
 import pytest
 from sauron.engine import Engine
 from pprint import pprint
-from tests.utils import job_import_module
+from tests.utils import job_import_module, job_import_module_verbose
 
 engine = Engine()
 
@@ -14,3 +14,13 @@ class TestFirstEngineCases:
         print(jobs)
         assert len(jobs) == 2
         assert [job for job in jobs.keys()] == ["always_true", "times_two"]
+
+    def test_can_parse_jobs_with_verbose_names(self):
+        engine.import_jobs(job_import_module_verbose)
+        jobs = engine.callables_collected
+        print(jobs)
+        assert len(jobs) == 2
+        assert [job["verbose_name"] for job in jobs.values()] == [
+            "True Always Is",
+            "Double that",
+        ]

--- a/tests/engine_tests/test_import_jobs.py
+++ b/tests/engine_tests/test_import_jobs.py
@@ -1,0 +1,12 @@
+import pytest
+from sauron.engine import Engine
+from pprint import pprint
+from tests.utils import job_import_module
+
+engine = Engine()
+
+
+class TestFirstEngineCases:
+    def test_can_parse_jobs(self):
+        engine.import_jobs(job_import_module)
+        assert False

--- a/tests/engine_tests/test_import_jobs.py
+++ b/tests/engine_tests/test_import_jobs.py
@@ -11,14 +11,12 @@ class TestFirstEngineCases:
     def test_can_parse_two_jobs(self):
         engine.import_jobs(job_import_module)
         jobs = engine.callables_collected
-        print(jobs)
         assert len(jobs) == 2
         assert [job for job in jobs.keys()] == ["always_true", "times_two"]
 
     def test_can_parse_jobs_with_verbose_names(self):
         engine.import_jobs(job_import_module_verbose)
         jobs = engine.callables_collected
-        print(jobs)
         assert len(jobs) == 2
         assert [job["verbose_name"] for job in jobs.values()] == [
             "True Always Is",

--- a/tests/engine_tests/test_import_jobs.py
+++ b/tests/engine_tests/test_import_jobs.py
@@ -1,3 +1,4 @@
+from typing import List
 import pytest
 from sauron.engine import Engine
 from pprint import pprint
@@ -7,6 +8,9 @@ engine = Engine()
 
 
 class TestFirstEngineCases:
-    def test_can_parse_jobs(self):
+    def test_can_parse_two_jobs(self):
         engine.import_jobs(job_import_module)
-        assert False
+        jobs = engine.callables_collected
+        print(jobs)
+        assert len(jobs) == 2
+        assert [job for job in jobs.keys()] == ["always_true", "times_two"]

--- a/tests/utils/job_import_module.py
+++ b/tests/utils/job_import_module.py
@@ -1,0 +1,16 @@
+from typing import Union
+from decimal import Decimal
+
+
+def always_true(context):
+    """
+    This method is a sample method to return True always
+    """
+    return True
+
+
+def times_two(context, input: Union[float, int, Decimal]):
+    """
+    This method is a sample method to return True always
+    """
+    return input * 2

--- a/tests/utils/job_import_module_verbose.py
+++ b/tests/utils/job_import_module_verbose.py
@@ -1,0 +1,36 @@
+from typing import Union, List, Tuple, Any
+from decimal import Decimal
+
+
+def always_true(context):
+    """
+    This method is a sample method to return True always
+    """
+    return True
+
+
+def times_two(context, input: Union[float, int, Decimal]):
+    """
+    This method is a sample method to return True always
+    """
+    return input * 2
+
+
+jobs_list: List[Tuple[str, Any]] = [
+    (
+        "always_true",
+        {
+            "verbose_name": "True Always Is",
+            "callable": always_true,
+            "job_type": "job",
+        },
+    ),
+    (
+        "times_two",
+        {
+            "verbose_name": "Double that",
+            "callable": times_two,
+            "job_type": "job",
+        },
+    ),
+]


### PR DESCRIPTION
# Description
Users should be able to import modules with jobs, conditions, actions and what not. There should be a way to override the name of the imported function, select which functions are imported and also provide a verbose name. This closes #45 

- [x] override jobs metadata in module (by the module designer)


updates #42 

## Type of change

New Feature

# How Has This Been Tested?

Simple testing

# Checklist:

- [x] My code follows the style guidelines of this project